### PR TITLE
fix: use canonical XKB keysym names for modifier release binds

### DIFF
--- a/crates/config-lib/src/modifier.rs
+++ b/crates/config-lib/src/modifier.rs
@@ -14,11 +14,25 @@ pub enum Modifier {
 #[allow(clippy::must_use_candidate)]
 impl Modifier {
     pub fn to_l_key(&self) -> String {
+        self.to_keysym_l().to_string()
+    }
+    pub const fn to_keysym_l(&self) -> &'static str {
+        // XKB keysym names (xkbcommon-keysyms.h). xkbcommon's case-insensitive
+        // lookup accepts e.g. "alt_l", but "ctrl_l" is NOT a valid XKB keysym
+        // (the canonical name is "Control_L"). So we return canonical XKB names.
         match self {
-            Self::Alt => "alt_l".to_string(),
-            Self::Ctrl => "ctrl_l".to_string(),
-            Self::Super => "super_l".to_string(),
-            Self::None => String::new(),
+            Self::Alt => "Alt_L",
+            Self::Ctrl => "Control_L",
+            Self::Super => "Super_L",
+            Self::None => "",
+        }
+    }
+    pub const fn to_keysym_r(&self) -> &'static str {
+        match self {
+            Self::Alt => "Alt_R",
+            Self::Ctrl => "Control_R",
+            Self::Super => "Super_R",
+            Self::None => "",
         }
     }
     pub const fn to_str(&self) -> &'static str {

--- a/crates/windows-lib/src/keybinds.rs
+++ b/crates/windows-lib/src/keybinds.rs
@@ -50,7 +50,7 @@ pub fn generate_open_keybinds(windows: &Windows) -> Vec<ExecBind> {
         });
         binds.push(ExecBind {
             mods: vec![switch.modifier.to_str()],
-            key: format!("{}_l", switch.modifier.to_str()).into_boxed_str(),
+            key: switch.modifier.to_keysym_l().into(),
             exec: generate_transfer_socat(&ExternalTransferType::CloseSwitch(CloseSwitch {
                 switch: true,
             })),
@@ -62,7 +62,7 @@ pub fn generate_open_keybinds(windows: &Windows) -> Vec<ExecBind> {
         });
         binds.push(ExecBind {
             mods: vec![switch.modifier.to_str()],
-            key: format!("{}_r", switch.modifier.to_str()).into_boxed_str(),
+            key: switch.modifier.to_keysym_r().into(),
             exec: generate_transfer_socat(&ExternalTransferType::CloseSwitch(CloseSwitch {
                 switch: true,
             })),
@@ -74,7 +74,7 @@ pub fn generate_open_keybinds(windows: &Windows) -> Vec<ExecBind> {
         });
         binds.push(ExecBind {
             mods: vec!["SHIFT"],
-            key: Box::from("SHIFT_l"),
+            key: Box::from("Shift_L"),
             exec: generate_transfer_socat(&ExternalTransferType::CloseSwitch(CloseSwitch {
                 switch: true,
             })),
@@ -83,7 +83,7 @@ pub fn generate_open_keybinds(windows: &Windows) -> Vec<ExecBind> {
         });
         binds.push(ExecBind {
             mods: vec!["SHIFT"],
-            key: Box::from("SHIFT_r"),
+            key: Box::from("Shift_R"),
             exec: generate_transfer_socat(&ExternalTransferType::CloseSwitch(CloseSwitch {
                 switch: true,
             })),


### PR DESCRIPTION
Fixes #470.

## Problem

Under Hyprland 0.55+'s native Lua config manager, hyprshell fails to register **any** binds when `[windows.switch]` or `[windows.overview]` is configured with `modifier = "ctrl"`. The release-detection bind hyprshell auto-generates uses the keysym string `"ctrl_l"` (`"ctrl_r"`), which is not a valid XKB keysym — xkbcommon only knows `Control_L` / `Control_R`. Hyprland's strict Lua bind path rejects it, and hyprshell aborts bind registration on the first failure, so the entire switcher/overview becomes non-functional.

`alt`/`super` users don't see this because xkbcommon's case-insensitive lookup accepts `"alt_l"` → `Alt_L`, `"super_l"` → `Super_L`. Only the `ctrl` path is broken.

Full repro, journal output, and `xkb_keysym_from_name` C test data in #470.

## Fix

- Add `to_keysym_l()` / `to_keysym_r()` to `Modifier` returning canonical XKB names (`Alt_L`/`Control_L`/`Super_L` and the `_R` variants).
- Use them in `crates/windows-lib/src/keybinds.rs` where the release binds are generated (replacing `format!("{}_l", switch.modifier.to_str())`, which produced `ctrl_l` for `Modifier::Ctrl` because `to_str()` returns the modifier-prefix string, not a keysym name).
- Bump the two `"SHIFT_l"` / `"SHIFT_r"` literals to `"Shift_L"` / `"Shift_R"`. These already happened to work via case-insensitive lookup but are now consistent with the rest.
- `to_l_key()` is left in place (delegating to `to_keysym_l()`) so any external callers don't break.

## Verification

Built `4.10.3` + this patch on Arch (rustc 1.95.0) against running Hyprland 0.55.2 with `~/.config/hypr/hyprland.lua`. With `[windows.switch] modifier = "ctrl"` and `[windows.overview] modifier = "alt"`:

- Before: `journalctl --user -u hyprshell.service` shows `Failed to apply binds — Unknown keysym: "ctrl_l"` and no binds register.
- After: clean startup, Alt+Tab opens the overview, Ctrl+Tab opens the switcher, releasing the modifier auto-closes both.

`strings` on the rebuilt binary contains `Alt_L Control_L Super_L Alt_R Control_R Super_R` and no occurrences of `ctrl_l`/`ctrl_r`.