### PR TITLE
refactor(exec-lib): vendor hyprland toplevel mapping protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,9 +2224,11 @@ dependencies = [
  "rustix 1.1.4",
  "semver",
  "tracing",
+ "wayland-backend",
  "wayland-client",
  "wayland-protocols",
- "wayland-protocols-hyprland",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
 ]
 
 [[package]]
@@ -5123,20 +5125,6 @@ dependencies = [
  "wayland-client",
  "wayland-scanner",
  "wayland-server",
-]
-
-[[package]]
-name = "wayland-protocols-hyprland"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398431fac4608bdae919e5c21a1f53af76deb9fcafdf682912a506ecc945582f"
-dependencies = [
- "bitflags 2.13.1",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-protocols-wlr",
- "wayland-scanner",
 ]
 
 [[package]]

--- a/crates/exec-lib/Cargo.toml
+++ b/crates/exec-lib/Cargo.toml
@@ -19,14 +19,16 @@ core-lib.workspace = true
 semver.workspace = true
 regex.workspace = true
 hyprland = { package = "hyprshell-hyprland", path = "../../dep-crates/hyprland", features = ["async-lite", "dispatch", "keyword", "data", "listener", "ctl", "config", "lua", "trace"], default-features = false, version = "=4.11.0-alpha.1" }
+wayland-backend = { version = "0.3.11", optional = true }
 wayland-client = { version = "0.31.14", optional = true }
 wayland-protocols = { version = "0.32.13", features = ["client", "staging"], optional = true }
+wayland-protocols-wlr = { version = "0.3.9", features = ["client"], optional = true }
+wayland-scanner = { version = "0.31.7", optional = true }
 gbm = { version = "0.18", optional = true }
 rustix = { version = "1.1.4", features = ["fs", "mm"], optional = true }
-wayland-protocols-hyprland = { version = "1.2.0", features = ["client"], optional = true }
 
 [features]
-live_windows = ["dep:wayland-client", "dep:wayland-protocols", "dep:gbm", "dep:rustix", "dep:wayland-protocols-hyprland"]
+live_windows = ["dep:wayland-backend", "dep:wayland-client", "dep:wayland-protocols", "dep:wayland-protocols-wlr", "dep:wayland-scanner", "dep:gbm", "dep:rustix"]
 
 [lints]
 workspace = true

--- a/crates/exec-lib/protocols/hyprland-toplevel-mapping-v1.xml
+++ b/crates/exec-lib/protocols/hyprland-toplevel-mapping-v1.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="hyprland_toplevel_mapping_v1">
+  <copyright>
+    Copyright © 2025 WhySoBad
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  </copyright>
+
+  <description summary="mapping of toplevels to windows">
+    This protocol allows clients to retrieve the mapping of toplevels to hyprland window addresses.
+  </description>
+
+  <interface name="hyprland_toplevel_mapping_manager_v1" version="1">
+    <description summary="manager to request toplevel mappings">
+      This object is a manager which offers requests to retrieve a window address
+      for a toplevel.
+    </description>
+
+    <request name="get_window_for_toplevel">
+      <description summary="get window address for toplevel">
+        Get the window address for a toplevel.
+      </description>
+      <arg
+        name="handle"
+        type="new_id"
+        interface="hyprland_toplevel_window_mapping_handle_v1"
+      />
+      <arg
+        name="toplevel"
+        type="object"
+        interface="ext_foreign_toplevel_handle_v1"
+        summary="toplevel to get the window address for"
+      />
+    </request>
+
+    <request name="get_window_for_toplevel_wlr">
+      <description summary="get window address for wlr toplevel">
+        Get the window address for a wlr toplevel.
+      </description>
+      <arg
+        name="handle"
+        type="new_id"
+        interface="hyprland_toplevel_window_mapping_handle_v1"
+      />
+      <arg
+        name="toplevel"
+        type="object"
+        interface="zwlr_foreign_toplevel_handle_v1"
+        summary="wlr toplevel to get the window address for"
+      />
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their appropriate destroy
+        request has been called.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="hyprland_toplevel_window_mapping_handle_v1" version="1">
+    <description summary="toplevel to window mapping">
+      This object represents a mapping of a (wlr) toplevel to a window address.
+
+      Once created, the `window_address` event will be sent containing the address of the window
+      associated with the toplevel.
+      Should the mapping fail, the `failed` event will be sent.
+    </description>
+
+    <event name="window_address">
+      <description summary="address of the window">
+        The full 64bit window address. The `address` field contains the lower 32 bits whilst the
+        `address_hi` contains the upper 32 bits
+      </description>
+      <arg
+        name="address_hi"
+        type="uint"
+        summary="upper 32 bits of the window address"
+      />
+      <arg
+        name="address"
+        type="uint"
+        summary="lower 32 bits of the window address"
+      />
+    </event>
+
+    <event name="failed">
+      <description summary="mapping failed">
+        The mapping of the toplevel to a window address failed. Most likely the window does not
+        exist (anymore).
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy handle">
+        Destroy the handle. This request can be sent at any time by the client.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/crates/exec-lib/src/lib.rs
+++ b/crates/exec-lib/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod collect;
 pub mod listener;
+#[cfg(feature = "live_windows")]
+pub mod protocols;
 pub mod switch;
 mod util;
 #[cfg(feature = "live_windows")]

--- a/crates/exec-lib/src/protocols.rs
+++ b/crates/exec-lib/src/protocols.rs
@@ -1,0 +1,36 @@
+//! Vendored Hyprland protocol bindings.
+//!
+//! The XML spec is vendored from `hyprwm/hyprland-protocols` at commit
+//! `bd153e76f751f150a09328dbdeb5e4fab9d23622`, the exact revision embedded in
+//! the former `wayland-protocols-hyprland` 1.2.0 dependency. It is licensed
+//! under BSD-3-Clause.
+//!
+//! Bindings are generated at compile time by `wayland-scanner`.
+
+pub mod toplevel_mapping {
+    pub mod v1 {
+        /// Client-side API of this protocol.
+        pub mod client {
+            #![allow(dead_code, non_camel_case_types, unused_unsafe, unused_variables)]
+            #![allow(non_upper_case_globals, non_snake_case, unused_imports)]
+            #![allow(missing_docs, clippy::all, clippy::pedantic, clippy::nursery)]
+
+            use wayland_client;
+            use wayland_client::protocol::*;
+            use wayland_protocols::ext::foreign_toplevel_list::v1::client::*;
+            use wayland_protocols_wlr::foreign_toplevel::v1::client::*;
+
+            pub mod __interfaces {
+                use wayland_client::protocol::__interfaces::*;
+                use wayland_protocols::ext::foreign_toplevel_list::v1::client::__interfaces::*;
+                use wayland_protocols_wlr::foreign_toplevel::v1::client::__interfaces::*;
+                wayland_scanner::generate_interfaces!(
+                    "./protocols/hyprland-toplevel-mapping-v1.xml"
+                );
+            }
+            use self::__interfaces::*;
+
+            wayland_scanner::generate_client_code!("./protocols/hyprland-toplevel-mapping-v1.xml");
+        }
+    }
+}

--- a/crates/exec-lib/src/wayland_capture.rs
+++ b/crates/exec-lib/src/wayland_capture.rs
@@ -14,7 +14,7 @@ use wayland_protocols::ext::image_copy_capture::v1::client::ext_image_copy_captu
 use wayland_protocols::wp::linux_dmabuf::zv1::client::zwp_linux_buffer_params_v1;
 use wayland_protocols::wp::linux_dmabuf::zv1::client::zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1;
 
-use wayland_protocols_hyprland::toplevel_mapping::v1::client::hyprland_toplevel_mapping_manager_v1::HyprlandToplevelMappingManagerV1;
+use crate::protocols::toplevel_mapping::v1::client::hyprland_toplevel_mapping_manager_v1::HyprlandToplevelMappingManagerV1;
 
 use core_lib::ClientId;
 use tracing::trace;
@@ -134,9 +134,9 @@ mod wl_impls {
     use wayland_protocols::ext::image_copy_capture::v1::client::ext_image_copy_capture_session_v1;
     use wayland_protocols::ext::image_copy_capture::v1::client::ext_image_copy_capture_session_v1::ExtImageCopyCaptureSessionV1;
     use wayland_protocols::wp::linux_dmabuf::zv1::client::zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1;
-    use wayland_protocols_hyprland::toplevel_mapping::v1::client::hyprland_toplevel_mapping_manager_v1::HyprlandToplevelMappingManagerV1;
-    use wayland_protocols_hyprland::toplevel_mapping::v1::client::hyprland_toplevel_window_mapping_handle_v1;
-    use wayland_protocols_hyprland::toplevel_mapping::v1::client::hyprland_toplevel_window_mapping_handle_v1::HyprlandToplevelWindowMappingHandleV1;
+    use crate::protocols::toplevel_mapping::v1::client::hyprland_toplevel_mapping_manager_v1::HyprlandToplevelMappingManagerV1;
+    use crate::protocols::toplevel_mapping::v1::client::hyprland_toplevel_window_mapping_handle_v1;
+    use crate::protocols::toplevel_mapping::v1::client::hyprland_toplevel_window_mapping_handle_v1::HyprlandToplevelWindowMappingHandleV1;
 
     impl Dispatch<HyprlandToplevelWindowMappingHandleV1, ObjectId> for AppState {
         fn event(
@@ -157,7 +157,6 @@ mod wl_impls {
                     proxy.destroy();
                 }
                 hyprland_toplevel_window_mapping_handle_v1::Event::Failed => proxy.destroy(),
-                _ => {}
             }
         }
     }
@@ -843,8 +842,8 @@ mod empty_impls {
     use wayland_protocols::wp::linux_dmabuf::zv1::client::zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1;
     use wayland_protocols::wp::linux_dmabuf::zv1::client::zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1;
     use wayland_protocols::wp::linux_dmabuf::zv1::client::{zwp_linux_buffer_params_v1, zwp_linux_dmabuf_v1};
-    use wayland_protocols_hyprland::toplevel_mapping::v1::client::hyprland_toplevel_mapping_manager_v1;
-    use wayland_protocols_hyprland::toplevel_mapping::v1::client::hyprland_toplevel_mapping_manager_v1::HyprlandToplevelMappingManagerV1;
+    use crate::protocols::toplevel_mapping::v1::client::hyprland_toplevel_mapping_manager_v1;
+    use crate::protocols::toplevel_mapping::v1::client::hyprland_toplevel_mapping_manager_v1::HyprlandToplevelMappingManagerV1;
 
     impl Dispatch<HyprlandToplevelMappingManagerV1, ()> for AppState {
         fn event(

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -3,9 +3,18 @@
   pkgs,
 }:
 rec {
+  # Vendored wayland protocol XML files must be kept in the cargo source
+  # tree since they are read at build time by wayland-scanner.
+  src = pkgs.lib.cleanSourceWith {
+    src = ../.;
+    filter = path: type:
+      (craneLib.filterCargoSources path type)
+      || (type == "regular" && pkgs.lib.hasSuffix ".xml" path);
+  };
+
   commonArgs = {
     pname = "hyprshell";
-    src = ../.;
+    inherit src;
     version = (pkgs.lib.trivial.importTOML ../Cargo.toml).workspace.package.version;
 
     meta = {
@@ -46,7 +55,7 @@ rec {
   cargoArtifacts = craneLib.buildDepsOnly (
     commonArgs
     // {
-      src = craneLib.cleanCargoSource ../.;
+      inherit src;
     }
   );
 


### PR DESCRIPTION
As discussed in #488, this vendors the hyprland-toplevel-mapping-v1.xml protocol spec directly from hyprwm/hyprland-protocols (commit bd153e76f751f150a09328dbdeb5e4fab9d23622, the exact revision embedded in wayland-protocols-hyprland 1.2.0) and drops the wayland-protocols-hyprland crate.

Bindings are generated at compile time with wayland-scanner, using the same module layout as the former crate, so the diff in wayland_capture.rs is limited to the import paths.

Notes:

- wayland-protocols-wlr becomes a direct dependency: the protocol's get_window_for_toplevel_wlr request references zwlr_foreign_toplevel_handle_v1. It was already in the workspace lock file.
- Dropping the crate also removes its LGPL-3.0 dependency from the tree; the vendored XML is BSD-3-Clause.
- nix/build.nix keeps .xml files in the cargo source tree since crane's filterCargoSources would otherwise exclude them.

Regarding avoiding hyprland-specific protocols entirely: the toplevel mapping is what ties Wayland toplevels to Hyprland window addresses, which hyprshell identifies clients by. I don't see a standard protocol providing that mapping, so this one stays.