### PR TITLE
fix(windows-lib): release thumbnails after rendered frame

### DIFF
--- a/crates/exec-lib/src/wayland_capture.rs
+++ b/crates/exec-lib/src/wayland_capture.rs
@@ -1,5 +1,5 @@
-use std::collections::{HashMap, VecDeque};
-use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use std::collections::HashMap;
+use std::os::fd::{AsFd, OwnedFd};
 
 pub use wayland_client::backend::ObjectId;
 use wayland_client::backend::WaylandError;
@@ -33,10 +33,10 @@ pub struct FrameStats {
 
 /// Result of a window capture via DMA-BUF.
 ///
-/// The file descriptor refers to a GBM buffer object and can be passed
-/// to `GdkDmabufTextureBuilder` for zero-copy GPU texture import.
-pub struct DmabufResult<'a> {
-    pub fd: BorrowedFd<'a>,
+/// The owned file descriptor is a duplicate of the GBM buffer fd and must be
+/// kept alive for as long as any texture imported from it is used.
+pub struct DmabufResult {
+    pub fd: OwnedFd,
     pub fourcc: u32,
     pub modifier: u64,
     pub width: u32,
@@ -51,9 +51,8 @@ pub struct WindowCapture {
     frame: Option<ExtImageCopyCaptureFrameV1>,
     buffer: WlBuffer,
     fd: OwnedFd,
-    dmabuf_bo: Option<gbm::BufferObject<()>>,
-    retired_bos: VecDeque<(gbm::BufferObject<()>, OwnedFd)>,
     fourcc: Option<u32>,
+    modifier: u64,
     width: u32,
     height: u32,
     stride: u32,
@@ -434,13 +433,12 @@ impl CaptureManager {
             .count()
     }
 
-    pub fn take_output(&self, index: &ObjectId) -> Result<DmabufResult<'_>> {
+    pub fn take_output(&self, index: &ObjectId) -> Result<DmabufResult> {
         let wc = &self.captures[index];
-        let bo = wc.dmabuf_bo.as_ref().ok_or("no dmabuf buffer object")?;
         Ok(DmabufResult {
-            fd: wc.fd.as_fd(),
+            fd: wc.fd.try_clone()?,
             fourcc: wc.fourcc.ok_or("no fourcc format")?,
-            modifier: bo.modifier().into(),
+            modifier: wc.modifier,
             width: wc.width,
             height: wc.height,
             stride: wc.stride,
@@ -699,15 +697,6 @@ impl CaptureManager {
             );
             let size = stride * height;
 
-            let (dmabuf_bo, fourcc, fd, buffer, stride, size) = (
-                Some(gbm_bo),
-                Some(*chosen_fmt),
-                dmabuf_fd,
-                buffer,
-                stride,
-                size,
-            );
-
             trace!("Capture allocated: {width}x{height}");
             window_captures.insert(
                 id,
@@ -715,10 +704,9 @@ impl CaptureManager {
                     session,
                     frame: None,
                     buffer,
-                    fd,
-                    dmabuf_bo,
-                    retired_bos: VecDeque::new(),
-                    fourcc,
+                    fd: dmabuf_fd,
+                    fourcc: Some(*chosen_fmt),
+                    modifier: mod_val,
                     width,
                     height,
                     stride,
@@ -810,17 +798,11 @@ impl CaptureManager {
             &self.event_queue.handle(),
             index.clone(),
         );
-        if let Some(old_bo) = wc.dmabuf_bo.take() {
-            let old_fd = std::mem::replace(&mut wc.fd, dmabuf_fd);
-            wc.retired_bos.push_back((old_bo, old_fd));
-            while wc.retired_bos.len() > 3 {
-                wc.retired_bos.pop_front();
-            }
-        }
 
-        wc.dmabuf_bo = Some(gbm_bo);
+        wc.fd = dmabuf_fd;
         wc.buffer = buffer;
         wc.fourcc = Some(*chosen_fmt);
+        wc.modifier = mod_val;
         wc.width = width;
         wc.height = height;
         wc.stride = stride;

--- a/crates/windows-lib/src/overview/root.rs
+++ b/crates/windows-lib/src/overview/root.rs
@@ -16,11 +16,15 @@ use relm4::adw::glib::ControlFlow;
 use relm4::adw::prelude::*;
 use relm4::adw::{glib, gtk};
 use relm4::prelude::*;
+#[cfg(feature = "live_windows")]
+use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::Duration;
-use tracing::{debug, error, trace, warn};
+#[cfg(feature = "live_windows")]
+use tracing::warn;
+use tracing::{debug, error, trace};
 
 const KILL_TIMEOUT: Duration = Duration::from_millis(200);
 #[cfg(feature = "live_windows")]
@@ -42,7 +46,11 @@ pub struct OverviewRoot {
     #[cfg(feature = "live_windows")]
     capture_manager: Option<CaptureManager>,
     #[cfg(feature = "live_windows")]
-    timer_handle: Option<glib::SourceId>,
+    timer_handle: Option<Rc<Cell<bool>>>,
+    #[cfg(feature = "live_windows")]
+    pending_hides: usize,
+    #[cfg(feature = "live_windows")]
+    pending_switch: Option<SwitchAction>,
     #[cfg(feature = "live_windows")]
     thumbnail_refresh_ms: u64,
     #[cfg(feature = "live_windows")]
@@ -62,6 +70,8 @@ pub enum OverviewRootInput {
     ReloadOverview,
     #[cfg(feature = "live_windows")]
     RefreshThumbnails,
+    #[cfg(feature = "live_windows")]
+    WindowHidden,
 }
 
 #[derive(Debug)]
@@ -129,6 +139,8 @@ impl SimpleComponent for OverviewRoot {
                         OverviewWindowOutput::ClickedC(cl) => {
                             OverviewRootInput::CloseOverviewClickC(cl)
                         }
+                        #[cfg(feature = "live_windows")]
+                        OverviewWindowOutput::Hidden => OverviewRootInput::WindowHidden,
                     });
                 windows.entry(monitor.id).insert_entry(overview_window);
             }
@@ -159,6 +171,10 @@ impl SimpleComponent for OverviewRoot {
             capture_manager: None,
             #[cfg(feature = "live_windows")]
             timer_handle: None,
+            #[cfg(feature = "live_windows")]
+            pending_hides: 0,
+            #[cfg(feature = "live_windows")]
+            pending_switch: None,
             #[cfg(feature = "live_windows")]
             thumbnail_refresh_ms: init.thumbnail_refresh_ms,
             #[cfg(feature = "live_windows")]
@@ -246,6 +262,13 @@ impl SimpleComponent for OverviewRoot {
             }
             #[cfg(feature = "live_windows")]
             OverviewRootInput::RefreshThumbnails => self.refresh_thumbnails(&sender),
+            #[cfg(feature = "live_windows")]
+            OverviewRootInput::WindowHidden => {
+                if self.pending_hides > 0 {
+                    self.pending_hides -= 1;
+                    self.check_pending_hides();
+                }
+            }
         }
     }
 }
@@ -270,6 +293,13 @@ impl OverviewRoot {
                 return;
             }
         };
+        // The overview is reopening: discard any still-pending deferred switch
+        // and reset the hide counter from the previous close.
+        #[cfg(feature = "live_windows")]
+        {
+            self.pending_hides = 0;
+            self.pending_switch = None;
+        }
         self.data = OverviewData {
             active,
             hypr_data: hypr_data.clone(),
@@ -281,20 +311,23 @@ impl OverviewRoot {
             self.capture_manager = CaptureManager::new().map_err(|e| error!("{e}")).ok();
             self.thumbnail_burst = true;
             let sender = sender.clone();
-            self.timer_handle = Some(glib::timeout_add_local(
-                Duration::from_millis(THUMBNAIL_BURST_MS),
-                move || {
-                    if sender
-                        .input_sender()
-                        .send(OverviewRootInput::RefreshThumbnails)
-                        .is_err()
-                    {
-                        warn!("Failed to send refresh thumbnails");
-                        return ControlFlow::Break;
-                    }
-                    ControlFlow::Continue
-                },
-            ));
+            let cancel = Rc::new(Cell::new(false));
+            self.timer_handle = Some(cancel.clone());
+            let _ = glib::timeout_add_local(Duration::from_millis(THUMBNAIL_BURST_MS), move || {
+                if cancel.get() {
+                    // overview was closed while the timer was pending
+                    return ControlFlow::Break;
+                }
+                if sender
+                    .input_sender()
+                    .send(OverviewRootInput::RefreshThumbnails)
+                    .is_err()
+                {
+                    warn!("Failed to send refresh thumbnails");
+                    return ControlFlow::Break;
+                }
+                ControlFlow::Continue
+            });
         }
     }
 
@@ -341,54 +374,129 @@ impl OverviewRoot {
         }
     }
 
+    /// Defer the client/workspace switch until after the overview windows have
+    /// been hidden. Without `live_windows` the windows are hidden synchronously
+    /// and an idle callback is enough.
+    #[cfg(not(feature = "live_windows"))]
+    #[allow(clippy::needless_pass_by_ref_mut, clippy::unused_self)]
+    fn defer_switch<F>(&mut self, f: F)
+    where
+        F: FnOnce() + 'static,
+    {
+        let mut f = Some(f);
+        let _ = glib::idle_add_local(move || {
+            if let Some(f) = f.take() {
+                f();
+            }
+            ControlFlow::Break
+        });
+    }
+
     fn close_overview(&mut self, do_switch: bool) {
         for window in self.windows.values() {
             window.emit(OverviewWindowInput::CloseOverview);
         }
 
-        if do_switch {
-            if let Some(id) = self.data.active.client {
-                debug!(
-                    "Switching to client {}",
-                    self.data
-                        .hypr_data
-                        .clients
-                        .iter()
-                        .find(|(cid, _)| *cid == id)
-                        .map_or_else(|| "<Unknown>".to_string(), |(_, c)| c.title.clone())
-                );
-                // Defer execution to ensure window is hidden first
-                glib::idle_add_local(move || {
-                    if let Err(e) = switch_client(id) {
-                        tracing::warn!("Failed to switch to client {id:?}: {e}");
-                    }
-                    ControlFlow::Break
-                });
+        #[cfg(feature = "live_windows")]
+        {
+            // Wait for every child window to report that it finished its
+            // after-paint hide before running the switch: the parent really
+            // waits for all windows instead of a fixed delay. If there are no
+            // windows the switch runs immediately.
+            self.pending_hides = self.windows.len();
+            self.pending_switch = if do_switch {
+                Some(self.resolve_switch_action())
             } else {
-                let id = self.data.active.workspace;
-                debug!(
-                    "Switching to workspace {}",
-                    self.data
-                        .hypr_data
-                        .workspaces
-                        .iter()
-                        .find(|(wid, _)| *wid == id)
-                        .map_or_else(|| "<Unknown>".to_string(), |(_, w)| w.name.clone())
-                );
-                glib::idle_add_local(move || {
-                    if let Err(e) = switch_workspace(id) {
-                        tracing::warn!("Failed to switch to workspace {id:?}: {e}");
-                    }
-                    ControlFlow::Break
-                });
+                None
+            };
+            self.check_pending_hides();
+        }
+        #[cfg(not(feature = "live_windows"))]
+        {
+            if do_switch {
+                if let Some(id) = self.data.active.client {
+                    debug!(
+                        "Switching to client {}",
+                        self.data
+                            .hypr_data
+                            .clients
+                            .iter()
+                            .find(|(cid, _)| *cid == id)
+                            .map_or_else(|| "<Unknown>".to_string(), |(_, c)| c.title.clone())
+                    );
+                    // Defer execution to ensure window is hidden first
+                    self.defer_switch(move || {
+                        if let Err(e) = switch_client(id) {
+                            tracing::warn!("Failed to switch to client {id:?}: {e}");
+                        }
+                    });
+                } else {
+                    let id = self.data.active.workspace;
+                    debug!(
+                        "Switching to workspace {}",
+                        self.data
+                            .hypr_data
+                            .workspaces
+                            .iter()
+                            .find(|(wid, _)| *wid == id)
+                            .map_or_else(|| "<Unknown>".to_string(), |(_, w)| w.name.clone())
+                    );
+                    self.defer_switch(move || {
+                        if let Err(e) = switch_workspace(id) {
+                            tracing::warn!("Failed to switch to workspace {id:?}: {e}");
+                        }
+                    });
+                }
             }
         }
         #[cfg(feature = "live_windows")]
         {
-            if let Some(handle) = self.timer_handle.take() {
-                handle.remove();
+            if let Some(cancel) = self.timer_handle.take() {
+                cancel.set(true);
             }
             self.capture_manager = None;
+        }
+    }
+
+    /// Resolve the client/workspace the switch action must activate.
+    #[cfg(feature = "live_windows")]
+    fn resolve_switch_action(&self) -> SwitchAction {
+        if let Some(id) = self.data.active.client {
+            debug!(
+                "Switching to client {}",
+                self.data
+                    .hypr_data
+                    .clients
+                    .iter()
+                    .find(|(cid, _)| *cid == id)
+                    .map_or_else(|| "<Unknown>".to_string(), |(_, c)| c.title.clone())
+            );
+            SwitchAction::Client(id)
+        } else {
+            let id = self.data.active.workspace;
+            debug!(
+                "Switching to workspace {}",
+                self.data
+                    .hypr_data
+                    .workspaces
+                    .iter()
+                    .find(|(wid, _)| *wid == id)
+                    .map_or_else(|| "<Unknown>".to_string(), |(_, w)| w.name.clone())
+            );
+            SwitchAction::Workspace(id)
+        }
+    }
+
+    /// Run the pending switch once every child window reported its hide. If
+    /// there are no windows to wait for, this runs immediately. Late
+    /// `WindowHidden` events arriving after a reopen are ignored because the
+    /// counter is reset to zero and the pending action to `None`.
+    #[cfg(feature = "live_windows")]
+    fn check_pending_hides(&mut self) {
+        if self.pending_hides == 0 {
+            if let Some(action) = self.pending_switch.take() {
+                action.run();
+            }
         }
     }
 
@@ -482,17 +590,23 @@ impl OverviewRoot {
         if self.thumbnail_burst && mgr.pending_count() == 0 {
             self.thumbnail_burst = false;
             // all initial thumbnails are loaded
-            // remove initial thumbnail burst timer
-            if let Some(h) = self.timer_handle.take() {
-                h.remove();
+            // cancel the initial thumbnail burst timer
+            if let Some(cancel) = self.timer_handle.take() {
+                cancel.set(true);
             }
             // start new slower timer if thumbnail_refresh_ms is set
             if self.thumbnail_refresh_ms != 0 {
                 trace!("Switching from thumbnail_burst refresh to slow refresh");
                 let sender = sender.clone();
-                self.timer_handle = Some(glib::timeout_add_local(
+                let cancel = Rc::new(Cell::new(false));
+                self.timer_handle = Some(cancel.clone());
+                let _ = glib::timeout_add_local(
                     Duration::from_millis(self.thumbnail_refresh_ms),
                     move || {
+                        if cancel.get() {
+                            // overview was closed while the timer was pending
+                            return ControlFlow::Break;
+                        }
                         if sender
                             .input_sender()
                             .send(OverviewRootInput::RefreshThumbnails)
@@ -503,7 +617,7 @@ impl OverviewRoot {
                         }
                         ControlFlow::Continue
                     },
-                ));
+                );
             } else {
                 trace!("All initial thumbnail captures loaded");
             }
@@ -535,6 +649,32 @@ impl Default for OverviewData {
                 monitor: -1,
             },
             hypr_data: HyprlandData::default(),
+        }
+    }
+}
+
+/// Switch to run once every overview window has finished its after-paint hide.
+#[cfg(feature = "live_windows")]
+#[derive(Debug)]
+enum SwitchAction {
+    Client(ClientId),
+    Workspace(WorkspaceId),
+}
+
+#[cfg(feature = "live_windows")]
+impl SwitchAction {
+    fn run(self) {
+        match self {
+            SwitchAction::Client(id) => {
+                if let Err(e) = switch_client(id) {
+                    tracing::warn!("Failed to switch to client {id:?}: {e}");
+                }
+            }
+            SwitchAction::Workspace(id) => {
+                if let Err(e) = switch_workspace(id) {
+                    tracing::warn!("Failed to switch to workspace {id:?}: {e}");
+                }
+            }
         }
     }
 }

--- a/crates/windows-lib/src/overview/window.rs
+++ b/crates/windows-lib/src/overview/window.rs
@@ -4,11 +4,17 @@ use core_lib::{
 };
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use regex::Regex;
+#[cfg(feature = "live_windows")]
+use relm4::adw::gtk::glib;
 use relm4::adw::prelude::*;
 use relm4::adw::{gdk, gtk};
 use relm4::factory::FactoryVecDeque;
 use relm4::gtk::{Orientation, SelectionMode};
 use relm4::{ComponentParts, ComponentSender, SimpleComponent};
+#[cfg(feature = "live_windows")]
+use std::cell::RefCell;
+#[cfg(feature = "live_windows")]
+use std::rc::Rc;
 use tracing::trace;
 
 #[derive(Debug)]
@@ -25,6 +31,10 @@ pub struct OverviewWindow {
     live_thumbnails: bool,
     #[cfg(feature = "live_windows")]
     live_thumbnails_icons: bool,
+    #[cfg(feature = "live_windows")]
+    after_paint_clock: Option<gdk::FrameClock>,
+    #[cfg(feature = "live_windows")]
+    after_paint_handler: Rc<RefCell<Option<glib::SignalHandlerId>>>,
 }
 
 #[derive(Debug)]
@@ -52,6 +62,8 @@ pub struct OverviewWindowInit {
 pub enum OverviewWindowOutput {
     Clicked(WorkspaceId),
     ClickedC(ClientId),
+    #[cfg(feature = "live_windows")]
+    Hidden,
 }
 
 #[relm4::component(pub)]
@@ -102,6 +114,10 @@ impl SimpleComponent for OverviewWindow {
             live_thumbnails: init.live_thumbnails,
             #[cfg(feature = "live_windows")]
             live_thumbnails_icons: init.live_thumbnails_icons,
+            #[cfg(feature = "live_windows")]
+            after_paint_clock: None,
+            #[cfg(feature = "live_windows")]
+            after_paint_handler: Rc::new(RefCell::new(None)),
         };
 
         let itemsw: gtk::FlowBox = model.items.widget().clone();
@@ -118,7 +134,7 @@ impl SimpleComponent for OverviewWindow {
         ComponentParts { model, widgets }
     }
 
-    fn update(&mut self, message: Self::Input, _sender: ComponentSender<Self>) {
+    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>) {
         trace!("overview::root::window::update: {message:?}");
         match message {
             OverviewWindowInput::SetGeneral(general) => {
@@ -143,14 +159,14 @@ impl SimpleComponent for OverviewWindow {
             OverviewWindowInput::CloseOverview => {
                 if self.open {
                     self.open = false;
-                    self.close_overview();
+                    self.close_overview(&sender);
                 } else {
                     trace!("not open");
                 }
             }
             OverviewWindowInput::ReloadOverview(data) => {
                 if self.open {
-                    self.reload_overview(&data);
+                    self.reload_overview(&data, &sender);
                 } else {
                     trace!("not open");
                 }
@@ -170,6 +186,15 @@ impl SimpleComponent for OverviewWindow {
 
 impl OverviewWindow {
     fn open_overview(&mut self, data: &OverviewWindowData) {
+        // Cancel any still-pending after-paint hide from a previous close
+        // before showing the window again: the old handler must not hide it.
+        #[cfg(feature = "live_windows")]
+        if let Some(clock) = self.after_paint_clock.take() {
+            if let Some(id) = self.after_paint_handler.borrow_mut().take() {
+                clock.disconnect(id);
+            }
+        }
+
         trace!("Showing window {:?}", self.window.id());
         self.window.set_visible(true);
         self.window.grab_focus();
@@ -241,20 +266,56 @@ impl OverviewWindow {
         }
     }
 
-    fn close_overview(&mut self) {
+    #[allow(unused_variables)]
+    fn close_overview(&mut self, sender: &ComponentSender<Self>) {
         trace!("Hiding window {:?}", self.window.id());
-        self.window.set_visible(false);
-
-        // Clear UI
+        // Clear UI first so the textures are released before the window is
+        // hidden, letting GSK render an empty frame and reclaim the GPU
+        // DMA-BUF images.
         {
             let mut lock = self.items.guard();
             lock.clear();
         }
+
+        #[cfg(feature = "live_windows")]
+        {
+            if let Some(clock) = self.window.frame_clock() {
+                // Keep the window visible until one empty frame has been
+                // rendered after the textures were cleared, then hide it. The
+                // `after-paint` frame clock signal fires once the frame is
+                // drawn, so no fixed delay is needed.
+                self.after_paint_clock = Some(clock.clone());
+                let handler = self.after_paint_handler.clone();
+                let window = self.window.downgrade();
+                let output = sender.output_sender().clone();
+                let id = clock.connect_after_paint(move |clock| {
+                    // Disconnect exactly once before hiding so the handler
+                    // never runs again, then tell the parent we are hidden.
+                    if let Some(id) = handler.borrow_mut().take() {
+                        clock.disconnect(id);
+                    }
+                    if let Some(window) = window.upgrade() {
+                        window.set_visible(false);
+                    }
+                    let _ = output.send(OverviewWindowOutput::Hidden);
+                });
+                *self.after_paint_handler.borrow_mut() = Some(id);
+                self.window.queue_draw();
+            } else {
+                // No frame clock available: hide directly instead of waiting.
+                self.window.set_visible(false);
+                let _ = sender.output_sender().send(OverviewWindowOutput::Hidden);
+            }
+        }
+        #[cfg(not(feature = "live_windows"))]
+        {
+            self.window.set_visible(false);
+        }
     }
 
-    fn reload_overview(&mut self, data: &OverviewWindowData) {
+    fn reload_overview(&mut self, data: &OverviewWindowData, sender: &ComponentSender<Self>) {
         if data.clients.is_empty() {
-            self.close_overview();
+            self.close_overview(sender);
             return;
         }
         self.populate_workspace_mode(data, self.general.scale);

--- a/crates/windows-lib/src/shared/capture_utils.rs
+++ b/crates/windows-lib/src/shared/capture_utils.rs
@@ -1,11 +1,41 @@
 use std::collections::HashMap;
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, OwnedFd};
 
 use relm4::adw::gtk;
 use tracing::{trace, warn};
 
 use core_lib::ClientId;
 use exec_lib::wayland_capture::{CaptureManager, ObjectId};
+
+use gtk::glib::{ffi as glib_ffi, gobject_ffi, object::ObjectType};
+
+/// Key attached to the texture so the dmabuf fd stays open for as long as the
+/// `GdkTexture` is alive.
+fn attach_dmabuf_fd(texture: &gtk::gdk::Texture, fd: OwnedFd) {
+    static DMABUF_FD_KEY: &std::ffi::CStr = c"hyprshell-windows-lib:dmabuf-fd";
+
+    unsafe extern "C" fn drop_owned_fd(data: glib_ffi::gpointer) {
+        if !data.is_null() {
+            // Safety: the box was created in attach_dmabuf_fd and is freed
+            // exactly once, when the object's qdata is destroyed.
+            unsafe {
+                drop(Box::from_raw(data as *mut OwnedFd));
+            }
+        }
+    }
+
+    // Safety: the texture outlives this call, and the boxed fd is only
+    // released by the object's qdata destroy notify when the texture dies.
+    unsafe {
+        let obj = texture.as_ptr() as *mut gobject_ffi::GObject;
+        gobject_ffi::g_object_set_data_full(
+            obj,
+            DMABUF_FD_KEY.as_ptr(),
+            Box::into_raw(Box::new(fd)) as glib_ffi::gpointer,
+            Some(drop_owned_fd),
+        );
+    }
+}
 
 pub fn refresh_captures(
     mgr: &mut CaptureManager,
@@ -79,7 +109,10 @@ pub fn refresh_captures(
                         .build()
                 };
                 match tex {
-                    Ok(t) => Some(t),
+                    Ok(t) => {
+                        attach_dmabuf_fd(&t, output.fd);
+                        Some(t)
+                    }
                     Err(e) => {
                         warn!("Failed to create texture for client {client_id}: {e}");
                         None

--- a/crates/windows-lib/src/switch/root.rs
+++ b/crates/windows-lib/src/switch/root.rs
@@ -3,12 +3,14 @@ use crate::next::{find_next_client, find_next_workspace};
 #[cfg(feature = "live_windows")]
 use crate::shared::refresh_captures;
 use crate::shared::{Workspaces, WorkspacesInit, WorkspacesInput};
-use core_lib::{Active, ByFirst, Direction, HyprlandData, SWITCH_NAMESPACE};
+use core_lib::{Active, ByFirst, ClientId, Direction, HyprlandData, SWITCH_NAMESPACE, WorkspaceId};
 use exec_lib::switch::{switch_client, switch_workspace};
 #[cfg(feature = "live_windows")]
 use exec_lib::wayland_capture::CaptureManager;
 use gtk4_layer_shell::{KeyboardMode, Layer, LayerShell};
 use regex::Regex;
+#[cfg(feature = "live_windows")]
+use relm4::adw::gdk;
 use relm4::adw::glib::ControlFlow;
 use relm4::adw::gtk;
 use relm4::adw::gtk::glib;
@@ -16,6 +18,11 @@ use relm4::adw::prelude::*;
 use relm4::gtk::gdk::Key;
 use relm4::gtk::{EventControllerKey, Orientation, SelectionMode};
 use relm4::prelude::*;
+#[cfg(feature = "live_windows")]
+use std::cell::Cell;
+use std::cell::RefCell;
+#[cfg(feature = "live_windows")]
+use std::rc::Rc;
 use std::time::Duration;
 use tracing::{debug, error, trace, warn};
 
@@ -47,7 +54,11 @@ pub struct SwitchRoot {
     #[cfg(feature = "live_windows")]
     capture_manager: Option<CaptureManager>,
     #[cfg(feature = "live_windows")]
-    timer_handle: Option<glib::SourceId>,
+    timer_handle: Option<Rc<Cell<bool>>>,
+    #[cfg(feature = "live_windows")]
+    after_paint_clock: Option<gdk::FrameClock>,
+    #[cfg(feature = "live_windows")]
+    after_paint_handler: Rc<RefCell<Option<glib::SignalHandlerId>>>,
     #[cfg(feature = "live_windows")]
     thumbnail_refresh_ms: u64,
     #[cfg(feature = "live_windows")]
@@ -152,6 +163,10 @@ impl SimpleComponent for SwitchRoot {
             capture_manager: None,
             #[cfg(feature = "live_windows")]
             timer_handle: None,
+            #[cfg(feature = "live_windows")]
+            after_paint_clock: None,
+            #[cfg(feature = "live_windows")]
+            after_paint_handler: Rc::new(RefCell::new(None)),
             #[cfg(feature = "live_windows")]
             thumbnail_refresh_ms: init.thumbnail_refresh_ms,
             #[cfg(feature = "live_windows")]
@@ -295,6 +310,13 @@ impl SwitchRoot {
             hypr_data: hypr_data.clone(),
         };
 
+        #[cfg(feature = "live_windows")]
+        if let Some(clock) = self.after_paint_clock.take() {
+            if let Some(id) = self.after_paint_handler.borrow_mut().take() {
+                clock.disconnect(id);
+            }
+        }
+
         trace!("Showing window {:?}", self.window.id());
         self.window.set_visible(true);
         self.window.grab_focus();
@@ -310,20 +332,23 @@ impl SwitchRoot {
             self.capture_manager = CaptureManager::new().map_err(|e| error!("{e}")).ok();
             self.thumbnail_burst = true;
             let sender = sender.clone();
-            self.timer_handle = Some(glib::timeout_add_local(
-                Duration::from_millis(THUMBNAIL_BURST_MS),
-                move || {
-                    if sender
-                        .input_sender()
-                        .send(SwitchRootInput::RefreshThumbnails)
-                        .is_err()
-                    {
-                        warn!("Failed to send refresh thumbnails");
-                        return ControlFlow::Break;
-                    }
-                    ControlFlow::Continue
-                },
-            ));
+            let cancel = Rc::new(Cell::new(false));
+            self.timer_handle = Some(cancel.clone());
+            let _ = glib::timeout_add_local(Duration::from_millis(THUMBNAIL_BURST_MS), move || {
+                if cancel.get() {
+                    // switch was closed while the timer was pending
+                    return ControlFlow::Break;
+                }
+                if sender
+                    .input_sender()
+                    .send(SwitchRootInput::RefreshThumbnails)
+                    .is_err()
+                {
+                    warn!("Failed to send refresh thumbnails");
+                    return ControlFlow::Break;
+                }
+                ControlFlow::Continue
+            });
         }
     }
 
@@ -482,9 +507,9 @@ impl SwitchRoot {
 
     fn close_switch(&mut self, do_switch: bool) {
         trace!("Hiding window {:?}", self.window.id());
-        self.window.set_visible(false);
-
-        // Clear UI
+        // Clear UI first so the textures are released before the window is
+        // hidden, letting GSK render an empty frame and reclaim the GPU
+        // DMA-BUF images.
         {
             let mut lock = self.items.guard();
             lock.clear();
@@ -494,7 +519,11 @@ impl SwitchRoot {
             lock.clear();
         }
 
-        if do_switch {
+        // Resolve the switch target now, but only run it once the window is
+        // hidden so the still-visible layer surface doesn't steal focus. The
+        // target is stored in a `RefCell` because the after-paint handler
+        // takes `Fn` and must run the action at most once.
+        let switch_target = RefCell::new(if do_switch {
             if let Some(id) = self.data.active.client {
                 debug!(
                     "Switching to client {}",
@@ -505,13 +534,7 @@ impl SwitchRoot {
                         .find(|(cid, _)| *cid == id)
                         .map_or_else(|| "<Unknown>".to_string(), |(_, c)| c.title.clone())
                 );
-                // Defer execution to ensure window is hidden first
-                glib::idle_add_local(move || {
-                    if let Err(e) = switch_client(id) {
-                        warn!("Failed to switch to client {id:?}: {e}");
-                    }
-                    ControlFlow::Break
-                });
+                Some(SwitchAction::Client(id))
             } else {
                 let id = self.data.active.workspace;
                 debug!(
@@ -521,22 +544,62 @@ impl SwitchRoot {
                         .workspaces
                         .iter()
                         .find(|(wid, _)| *wid == id)
-                        .map_or_else(|| "<Unknown>".to_string(), |(_, w)| w.name.clone())
+                        .map_or_else(|| id.to_string(), |(_, w)| w.name.clone())
                 );
-                glib::idle_add_local(move || {
-                    if let Err(e) = switch_workspace(id) {
-                        tracing::warn!("Failed to switch to workspace {id:?}: {e}");
-                    }
-                    ControlFlow::Break
-                });
+                Some(SwitchAction::Workspace(id))
             }
-        }
+        } else {
+            None
+        });
+
         #[cfg(feature = "live_windows")]
         {
-            if let Some(handle) = self.timer_handle.take() {
-                handle.remove();
+            if let Some(cancel) = self.timer_handle.take() {
+                cancel.set(true);
             }
             self.capture_manager = None;
+
+            if let Some(clock) = self.window.frame_clock() {
+                // Keep the window visible until one empty frame has been
+                // rendered after the textures were cleared, then hide it and
+                // run the switch. The `after-paint` frame clock signal fires
+                // once the frame is drawn, so no fixed delay is needed.
+                self.after_paint_clock = Some(clock.clone());
+                let handler = self.after_paint_handler.clone();
+                let window = self.window.downgrade();
+                let id = clock.connect_after_paint(move |clock| {
+                    // Disconnect exactly once before hiding so the handler
+                    // never runs again.
+                    if let Some(id) = handler.borrow_mut().take() {
+                        clock.disconnect(id);
+                    }
+                    if let Some(window) = window.upgrade() {
+                        window.set_visible(false);
+                    }
+                    if let Some(action) = switch_target.borrow_mut().take() {
+                        action.run();
+                    }
+                });
+                *self.after_paint_handler.borrow_mut() = Some(id);
+                self.window.queue_draw();
+            } else {
+                // No frame clock available: hide directly instead of waiting.
+                self.window.set_visible(false);
+                if let Some(action) = switch_target.borrow_mut().take() {
+                    action.run();
+                }
+            }
+        }
+        #[cfg(not(feature = "live_windows"))]
+        {
+            self.window.set_visible(false);
+            // Defer execution to ensure window is hidden first
+            glib::idle_add_local(move || {
+                if let Some(action) = switch_target.borrow_mut().take() {
+                    action.run();
+                }
+                ControlFlow::Break
+            });
         }
     }
 
@@ -655,17 +718,23 @@ impl SwitchRoot {
         if self.thumbnail_burst && mgr.pending_count() == 0 {
             self.thumbnail_burst = false;
             // all initial thumbnails are loaded
-            // remove initial thumbnail burst timer
-            if let Some(h) = self.timer_handle.take() {
-                h.remove();
+            // cancel the initial thumbnail burst timer
+            if let Some(cancel) = self.timer_handle.take() {
+                cancel.set(true);
             }
             // start new slower timer if thumbnail_refresh_ms is set
             if self.thumbnail_refresh_ms != 0 {
                 trace!("Switching from thumbnail_burst refresh to slow refresh");
                 let sender = sender.clone();
-                self.timer_handle = Some(glib::timeout_add_local(
+                let cancel = Rc::new(Cell::new(false));
+                self.timer_handle = Some(cancel.clone());
+                let _ = glib::timeout_add_local(
                     Duration::from_millis(self.thumbnail_refresh_ms),
                     move || {
+                        if cancel.get() {
+                            // switch was closed while the timer was pending
+                            return ControlFlow::Break;
+                        }
                         if sender
                             .input_sender()
                             .send(SwitchRootInput::RefreshThumbnails)
@@ -676,7 +745,7 @@ impl SwitchRoot {
                         }
                         ControlFlow::Continue
                     },
-                ));
+                );
             } else {
                 trace!("All initial thumbnail captures loaded");
             }
@@ -698,6 +767,28 @@ impl SwitchRoot {
                         idx,
                         crate::switch::clients::ClientsInput::UpdateThumbnail(texture),
                     );
+                }
+            }
+        }
+    }
+}
+
+enum SwitchAction {
+    Client(ClientId),
+    Workspace(WorkspaceId),
+}
+
+impl SwitchAction {
+    fn run(self) {
+        match self {
+            SwitchAction::Client(id) => {
+                if let Err(e) = switch_client(id) {
+                    warn!("Failed to switch to client {id:?}: {e}");
+                }
+            }
+            SwitchAction::Workspace(id) => {
+                if let Err(e) = switch_workspace(id) {
+                    warn!("Failed to switch to workspace {id:?}: {e}");
                 }
             }
         }


### PR DESCRIPTION
## Problem

Live window thumbnails leave a significant amount of GPU memory allocated
after the overview or switch surface is closed. Reopening the surface can
also leave stale GLib callbacks behind, causing the next invocation to fail
or crash.

## Root cause

Thumbnail widgets keep references to GDK textures backed by imported DMA-BUF
images. Hiding the layer surface before GTK renders an updated scene prevents
GSK from observing that those images are no longer used. The images are then
kept by the GSK GPU cache until its normal garbage-collection timeout.

## Fix

Clear the thumbnail widgets before hiding the surface and wait for the
GdkFrameClock `after-paint` signal. This ensures that a frame without the
thumbnail textures has been rendered before the surface is hidden.

The overview waits for all monitor windows to complete this step before
performing a pending client or workspace switch. Frame handlers are
disconnected safely when a surface is reopened.

Refresh callbacks use cancellation tokens instead of removing potentially
expired GLib sources, avoiding crashes during rapid close and reopen cycles.

## DMA-BUF lifetime

Keep a duplicated file descriptor alive for each GDK DMA-BUF texture instead
of relying on a bounded list of retired GBM buffer objects. This makes the
DMA-BUF lifetime follow the texture that imported it and prevents closed file
descriptors from being reused after buffer reallocation.

This is an independent lifetime-safety fix for resize and reallocation
scenarios; it is not required for the normal VRAM cleanup path described
above.